### PR TITLE
Upgrade base image to latest go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM golang:1.14.2-alpine3.11 AS build-env
+FROM golang:1.19.3-alpine3.17 AS build-env
 RUN apk --no-cache add build-base git gcc
 ADD . /src
 RUN cd /src/cmd && go build -o prometheus-aggregate-exporter


### PR DESCRIPTION
changed to latest base image.  Tested in BTQ test, version 3.0.0 works.